### PR TITLE
Fixed the problem of not handling HTML entities.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,7 @@ const { RegisterHTMLHandler } = require("mathjax-full/js/handlers/html.js");
 const { AssistiveMmlHandler } = require("mathjax-full/js/a11y/assistive-mml.js");
 
 const { AllPackages } = require("mathjax-full/js/input/tex/AllPackages.js");
+require('mathjax-full/js/util/entities/all.js');
 
 const defaultOptions = {
   output: "svg",


### PR DESCRIPTION
Hello, thank you for the nice work, very helpful.

Recently I found it failed to handle HTML files that do not even contain mathjax expressions, for example:

```html
<!DOCTYPE html>
<html>
<body>
<ul>
<li>&ldquo;a&rdquo;</li>
<li>&copy;</li>
</ul>

</body>
</html>
```

It turns out that mathjax by default does not support HTML entities like `&ldquo;`, it is an issue of configuration, according to https://github.com/mathjax/MathJax-demos-node/issues/16

so by simply add `require('mathjax-full/js/util/entities/all.js');` to .eleventy.js the problem is gone, so far I am using it without any trouble
