### PR TITLE
Add MathJax stylesheet to output document

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,6 +59,9 @@ module.exports = function (eleventyConfig, options = {}) {
 
     cleanOutput(html, adaptor, options);
 
+    // add stylesheet to output document to visually hide assistive MathML
+    adaptor.append(html.document.head, OutputJax.styleSheet(html));
+
     return (
       adaptor.doctype(html.document) + "\n" + adaptor.outerHTML(adaptor.root(html.document)) + "\n"
     );


### PR DESCRIPTION
Thanks for building this plug-in! If you still maintain it, I would be happy if you can test and include this fix.

The assistive MathML element is not hidden if the corresponding CSS is not included in the output, which currently seems to be the case. This change adds the necessary `style` element to the document head. It is automatically produced by MathJax and only contains the CSS necessary for the given document.

Fixes #3 